### PR TITLE
[fix] empty weight series if no variable name is present

### DIFF
--- a/ponyexpress/strategies/spikyball.py
+++ b/ponyexpress/strategies/spikyball.py
@@ -162,7 +162,7 @@ def calc_prob(table: pd.DataFrame, params: ProbabilityConfiguration) -> pd.Serie
     5     6.0
     dtype: float64
     """
-    if params.weights:
+    if params.weights and len(params.weights) != 0:
         weights = [
             table[key].astype(float) * weight for key, weight in params.weights.items()
         ]
@@ -212,12 +212,12 @@ def sample_edges(
     """
     source_nodes = (
         outward_edges.reset_index()
-        .merge(nodes, left_on="source", right_on="name", validate="m:1")
+        .merge(nodes, left_on="source", right_on="name")
         .set_index("index")
     )
     target_nodes = (
         outward_edges.reset_index()
-        .merge(nodes, left_on="target", right_on="name", validate="m:1")
+        .merge(nodes, left_on="target", right_on="name")
         .set_index("index")
     )
 

--- a/tests/test_spikyball.py
+++ b/tests/test_spikyball.py
@@ -72,11 +72,18 @@ def test_calc_norm(value: Tuple[pd.Series, pd.Series, pd.Series], expected: floa
             pd.Series(dtype=float),
         ),
         (
-            (
+            (  # check whether nans propagate
                 pd.DataFrame({"a": [1, 2, 3, 4, nan]}),
                 ProbabilityConfiguration(1, {"a": 1}),
             ),
             pd.Series([1, 2, 3, 4, nan]),
+        ),
+        (
+            (  # check whether given no variable gives uniform weights
+                pd.DataFrame({"a": [1, 2, 3, 4, 5, 6]}),
+                ProbabilityConfiguration(1, {}),
+            ),
+            pd.Series([1, 1, 1, 1, 1, 1]),
         ),
     ],
 )
@@ -89,7 +96,7 @@ def test_calc_prob(
         Tuple[pd.DataFrame, ProbabilityConfiguration] : arguments to `calc_prob`
 
     expected :
-        pd.Series : the calculated unnormalized weight for the entity
+        pd.Series : the calculated weights for the entity
     """
     for to_test, as_expected in zip(calc_prob(*value), expected):
         if isnan(as_expected):


### PR DESCRIPTION
Fixed bug that emitted an empty weight series if no variable name is given in the spikyball configuration. Closes #22.