### PR TITLE
feat(csv): by default cache opened files in memory

### DIFF
--- a/ponyexpress/connectors/csv.py
+++ b/ponyexpress/connectors/csv.py
@@ -30,13 +30,13 @@ def csv_connector(
             _cache[configuration.edge_list_location] = pd.read_csv(
                 configuration.edge_list_location, dtype=str
             )
-        edges = _cache[configuration.edge_list_location]
+        edges = _cache[configuration.edge_list_location].copy()
         if configuration.node_list_location:
             if configuration.node_list_location not in _cache:
                 _cache[configuration.node_list_location] = pd.read_csv(
                     configuration.node_list_location, dtype=str
                 )
-            nodes = _cache[configuration.node_list_location]
+            nodes = _cache[configuration.node_list_location].copy()
         else:
             nodes = None
     else:

--- a/ponyexpress/connectors/csv.py
+++ b/ponyexpress/connectors/csv.py
@@ -1,11 +1,12 @@
 """A CSV-reading, network-rippin' connector for your testing purposes."""
 import dataclasses
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 
 from ponyexpress.types import PlugIn, fromdict
 
+_cache = {}
 
 @dataclasses.dataclass
 class CSVConnectorConfiguration:
@@ -14,21 +15,38 @@ class CSVConnectorConfiguration:
     edge_list_location: str
     mode: str
     node_list_location: Optional[str] = None
+    cache: bool = True
 
 
 def csv_connector(
     node_ids: List[str], configuration: Union[Dict, CSVConnectorConfiguration]
-) -> (pd.DataFrame, pd.DataFrame):
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """The CSV connector!"""
     if isinstance(configuration, dict):
         configuration = fromdict(CSVConnectorConfiguration, configuration)
 
-    edges = pd.read_csv(configuration.edge_list_location, dtype=str)
-    nodes = (
-        pd.read_csv(configuration.node_list_location, dtype=str)
-        if configuration.node_list_location
-        else None
-    )
+    if configuration.cache:
+        if configuration.edge_list_location not in _cache:
+            _cache[configuration.edge_list_location] = pd.read_csv(
+                configuration.edge_list_location, dtype=str
+            )
+        edges = _cache[configuration.edge_list_location]
+        if configuration.node_list_location:
+            if configuration.node_list_location not in _cache:
+                _cache[configuration.node_list_location] = pd.read_csv(
+                    configuration.node_list_location, dtype=str
+                )
+            nodes = _cache[configuration.node_list_location]
+        else:
+            nodes = None
+    else:
+        edges = pd.read_csv(configuration.edge_list_location, dtype=str)
+        nodes = (
+            pd.read_csv(configuration.node_list_location, dtype=str)
+            if configuration.node_list_location
+            else None
+        )
+
     if configuration.mode == "in":
         mask = edges["target"].isin(node_ids)
     elif configuration.mode == "out":

--- a/tests/connectors/test_csv_connector.py
+++ b/tests/connectors/test_csv_connector.py
@@ -2,6 +2,7 @@
 import pytest
 
 from ponyexpress.connectors import csv_connector
+from ponyexpress.connectors.csv import _cache
 
 # pylint: disable=redefined-outer-name
 
@@ -50,3 +51,10 @@ def test_retrieval_modes(mode, shape, seventh_grader_configuration):
     assert edges.shape == shape
     assert nodes.empty is False
     assert len(nodes.index) == 2
+
+def test_caching(seventh_grader_configuration):
+    """Should correctly cache the edges and nodes."""
+    seventh_grader_configuration["cache"] = True
+    _, _ = csv_connector(["1", "13"], seventh_grader_configuration)
+
+    assert seventh_grader_configuration["edge_list_location"] in _cache


### PR DESCRIPTION
Caches opened files in a module-level dict. Can be turned off in the configuration by settings:

```yaml
csv:
  cache: true
```
