### PR TITLE
feat: allow a configuration to be passed into `Spider`.

### DIFF
--- a/ponyexpress/__init__.py
+++ b/ponyexpress/__init__.py
@@ -1,5 +1,6 @@
 """.. include:: ../README.md"""
 
+from .spider import Spider
 from .types import Configuration
 
 __version__ = "0.1.0"


### PR DESCRIPTION
This feature enables us e.g. to use external templating and configuration building for running ensemble samplers or to rerun a job with different schema/database outputs.

This is not depending on the *new* routing architecture, but is the minimal possible implementation.