### PR TITLE
fix(plugins): Load default configuration, if nothing else is there.

### DIFF
--- a/spiderexpress/plugin_manager.py
+++ b/spiderexpress/plugin_manager.py
@@ -1,4 +1,5 @@
 """Manages access and information about spiderexpress' plug-in system."""
+
 import functools
 import importlib.metadata as mt
 import sys
@@ -46,7 +47,9 @@ def _(spec: str, group: str) -> Callable:
     plugin = _access_entry_point(spec, group)
     if not plugin:
         raise ValueError(f"{ spec } could not be found in { group }")
-    return plugin.callable
+    return functools.partial(
+        plugin.callable, configuration=plugin.default_configuration
+    )
 
 
 @get_plugin.register(dict)

--- a/spiderexpress/strategies/snowball.py
+++ b/spiderexpress/strategies/snowball.py
@@ -1,6 +1,6 @@
 """Snowball sampling strategy."""
 
-from typing import List
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
@@ -11,6 +11,7 @@ def snowball_strategy(
     edges: pd.DataFrame,
     nodes: pd.DataFrame,
     known_nodes: List[str],
+    configuration: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
 ):
     """Random sampling strategy."""
     # split the edges table into edges _inside_ and _outside_ of the known network
@@ -34,5 +35,5 @@ def snowball_strategy(
 
 
 snowball = PlugIn(
-    callable=snowball_strategy, default_configuration=None, metadata={}, tables={}
+    callable=snowball_strategy, default_configuration={}, metadata={}, tables={}
 )


### PR DESCRIPTION
**Problem**:

Loading a plugin only by `str` – its name – the manager returns the function without applying the default configuration. This leads to a situation where, if the project config states *only* the plugins name, thus, loading the plugin with not overriding configuration, depending on the plugin, the `spiderexpress` to raise and quit.